### PR TITLE
State module: new API

### DIFF
--- a/lib/cache_script.ml
+++ b/lib/cache_script.ml
@@ -2,7 +2,7 @@ let name = "opam-bin-cache.sh"
 
 let script ~workdir =
   let (^/) = Filename.concat in
-  let cache = OpamFilename.(to_string Op.(workdir // State.cache_path)) in
+  let cache = State.(p ~workdir cache_path) in
 
   {|#!/bin/sh -uex|} ^
 

--- a/lib/cache_script.ml
+++ b/lib/cache_script.ml
@@ -1,6 +1,8 @@
 let name = "opam-bin-cache.sh"
 
+(* NOTE: [workdir] needs to be an absolute path here! *)
 let script ~workdir =
+  assert (not (Filename.is_relative workdir));
   let (^/) = Filename.concat in
   let cache = State.(p ~workdir cache_path) in
 

--- a/lib/data.ml
+++ b/lib/data.ml
@@ -1,0 +1,140 @@
+open Utils
+
+let assoc k l =
+  try List.assoc k l with Not_found ->
+    Json.parse_error `Null "" (* XX *)
+let get_opt =
+  function Some x -> x | None -> Json.parse_error `Null "" (* XX *)
+
+module Package_report = struct
+  type build_log = string list
+  type changes = Changes (* fixme *)
+  type error_cause = [ `Fetch | `Build | `Install ]
+  type status =
+    | Success of { log : build_log; changes : changes }
+    | Error of { log : build_log; cause : error_cause }
+    | Aborted of { deps : Action.Set.t }
+    (* An [Aborted] status means that the package could not be built
+       because _for all possible ways of building the package_
+       at least one of its dependencies fails to build. *)
+  type t = OpamPackage.t * status
+
+  let status_of_json (j: Json.value): status =
+    let l = Json.get_dict j in
+    try
+      begin match Json.get_string (List.assoc "status" l) with
+        | "success" ->
+          Success { log = Json.get_list Json.get_string (List.assoc "log" l);
+                    changes = Changes (* TODO *) }
+        | "error" ->
+          let cause = match Json.get_string (List.assoc "cause" l) with
+            | "fetch" -> `Fetch
+            | "build" -> `Build
+            | "install" -> `Install
+            | _ -> raise Not_found
+          in
+          Error { log = Json.get_list Json.get_string (List.assoc "log" l); cause }
+        | "aborted" ->
+          let deps = match Action.Set.of_json (List.assoc "deps" l) with
+            | Some deps -> deps
+            | None -> raise Not_found
+          in
+          Aborted { deps }
+        | _ -> raise Not_found
+      end
+    with Not_found -> Json.parse_error `Null "" (* XX *)
+
+  let status_to_json = function
+    | Success { log; changes = Changes (* TODO *) } ->
+      `O [ ("status", `String "success");
+           ("log", Json.strings log) ]
+    | Error { log; cause } ->
+      let cause_s = match cause with
+        | `Fetch -> "fetch"
+        | `Build -> "build"
+        | `Install -> "install"
+      in
+      `O [ ("status", `String "error");
+           ("log", Json.strings log);
+           ("cause", `String cause_s) ]
+    | Aborted { deps } ->
+      `O [ ("status", `String "aborted");
+           ("deps", Action.Set.to_json deps) ]
+
+  let of_json (j: Json.t) : t =
+    let j = Json.value j in
+    let l = Json.get_dict j in
+    let pkg = assoc "package" l in
+    let pkg_report = assoc "report" l in
+    (get_opt (OpamPackage.of_json pkg),
+     status_of_json pkg_report)
+
+  let to_json (pkg, pkg_report) =
+    `O [ ("package", OpamPackage.to_json pkg);
+         ("report", status_to_json pkg_report) ]
+end
+
+module Cover_elt_plan = struct
+  type t = Lib.Cover_elt_plan.t
+
+  let of_json (j: Json.value): t =
+    try
+      let l = Json.get_dict j in
+      let get_opt = function Some x -> x | None -> raise Not_found in
+      { solution =
+          OpamSolver.solution_of_json (List.assoc "solution" l)
+          |> get_opt;
+        useful =
+          PkgSet.of_json (List.assoc "useful" l) |> get_opt; }
+    with Not_found -> Json.parse_error j "invalid cover element"
+
+  let to_json plan =
+    `O [ ("solution", OpamSolver.solution_to_json plan.Lib.Cover_elt_plan.solution);
+         ("useful", PkgSet.to_json plan.Lib.Cover_elt_plan.useful) ]
+
+  let opt_of_json (j: Json.t) : t option =
+    match j with
+    | `A [] -> None
+    | `A [ j' ] -> Some (of_json j')
+    | _ -> Json.parse_error (Json.value j)
+             "cover element plan: invalid format"
+
+  let opt_to_json = function
+    | None -> `A []
+    | Some elt -> `A [ to_json elt ]
+end
+
+module Cover = struct
+  type elt_report = Package_report.status OpamPackage.Map.t
+  type elt = Cover_elt_plan.t * elt_report
+  type t = elt list
+
+  let elt_report_of_json (j : Json.value): elt_report =
+    let report_of_json j = Some (Package_report.status_of_json j) in
+    match OpamPackage.Map.of_json report_of_json j with
+    | Some r -> r
+    | None -> Json.parse_error j "invalid cover report"
+
+  let elt_report_to_json (report: elt_report) =
+    OpamPackage.Map.to_json Package_report.status_to_json report
+
+  let elt_of_json (j: Json.value): elt =
+    Json.get_pair Cover_elt_plan.of_json elt_report_of_json j
+
+  let elt_to_json (elt: elt): Json.value =
+    Json.pair Cover_elt_plan.to_json elt_report_to_json elt
+
+  let of_json (j: Json.t): t =
+    Json.get_list elt_of_json (Json.value j)
+
+  let to_json (cover : t): Json.t =
+    Json.list elt_to_json cover
+end
+
+module Uninst = struct
+  let of_json j =
+    let j = Json.value j in
+    get_opt (PkgSet.of_json (Json.get_dict j |> assoc "uninst"))
+
+  let to_json set = `O [ "uninst", PkgSet.to_json set ]
+end

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (name marracheck_lib)
   (libraries opam-state opam-solver opam-client
-             oseq containers yojson ezjsonm lwt.unix))
+             oseq containers yojson ezjsonm lwt.unix dmap))

--- a/lib/fs.ml
+++ b/lib/fs.ml
@@ -1,0 +1,369 @@
+open Utils
+
+(* data format *)
+(* definition of [data_format] and [data_format_iseq] by Florian "octachron"
+   Angeletti. *)
+
+type _ data_cstr = ..
+
+module type DATA_CSTR = sig
+  type a
+  type _ data_cstr += Fmt: a data_cstr
+end
+
+type 'a data_format = (module DATA_CSTR with type a = 'a)
+
+let mk_data_format : type a. unit -> a data_format = fun () ->
+  (module struct type nonrec a = a type _ data_cstr += Fmt : a data_cstr end)
+
+type (_, _) eq = Eq : ('a, 'a) eq
+let data_format_iseq : type a b. a data_format -> b data_format -> (a, b) eq option =
+  fun (module M) (module N) ->
+  match M.Fmt, N.Fmt with
+  | M.Fmt, M.Fmt -> Some Eq
+  | _ -> None
+
+exception Cast_failure
+
+let data_format_eqbool : type a b. a data_format -> b data_format -> bool =
+  fun fmt1 fmt2 ->
+  match data_format_iseq fmt1 fmt2 with
+  | Some Eq -> true
+  | None -> false
+
+let cast_data : type a b. a data_format -> b data_format -> a -> b =
+  fun fmt1 fmt2 x ->
+  match data_format_iseq fmt1 fmt2 with
+  | Some Eq -> x
+  | None -> raise Cast_failure
+
+let cast_data_list : type a b. a data_format -> b data_format -> a list -> b list =
+  fun fmt1 fmt2 x ->
+  match data_format_iseq fmt1 fmt2 with
+  | Some Eq -> x
+  | None -> raise Cast_failure
+
+(* fstree *)
+
+type dircap = { git : bool }
+
+type fstree =
+  | StaticDir : {
+      contents : (string * fstree) list;
+      cap : dircap;
+    } -> fstree
+
+  | DynDir : {
+      schema : fstree;
+      cap : dircap;
+    } -> fstree
+
+  | ExtDir : fstree
+
+  | File : {
+      format : 'a data_format;
+      default : 'a option;
+      write : filename:string -> 'a -> unit;
+      read : filename:string -> ('a, string) Result.t;
+    } -> fstree
+
+  | AppendFile : {
+      format : 'a data_format;
+      append : filename:string -> 'a -> unit;
+      read_all : filename:string -> ('a list, string) Result.t;
+      write_all : filename:string -> 'a list -> unit;
+    } -> fstree
+
+(* fstree helpers *)
+
+let file_raw ~format ~default =
+  File {
+    format; default;
+    read = (fun ~filename ->
+      CCResult.guard_str (fun () ->
+        CCIO.with_in ~flags:[Open_binary;Open_rdonly] filename CCIO.read_all));
+    write = (fun ~filename str ->
+      CCIO.with_out ~flags:[Open_trunc;Open_wronly;Open_creat;Open_binary] filename
+        (fun cout -> output_string cout str))
+  }
+
+let file_json (type a) ~format ~(default: a option) ~of_json ~to_json =
+  File {
+    format; default;
+    read = (fun ~filename ->
+      CCIO.with_in ~flags:[Open_binary;Open_rdonly] filename
+        (fun cin ->
+           try Json.from_channel cin |> of_json |> Result.ok
+           with Json.Parse_error (_, _) ->
+             Error (Printf.sprintf "In %s: json parsing error" filename)));
+      write = (fun ~filename v ->
+        CCIO.with_out ~flags:[Open_trunc;Open_wronly;Open_creat;Open_binary] filename
+          (fun cout ->
+             Json.to_channel ~minify:false cout (to_json v))
+      );
+  }
+
+let appendfile_json ~format
+    ~(of_json : Json.t -> 'a)
+    ~(to_json : 'a -> Json.t)
+  =
+  AppendFile {
+    format;
+    append = (fun ~filename elt ->
+      CCIO.with_out ~flags:[Open_binary;Open_append;Open_wronly;Open_creat] filename
+        (fun cout ->
+           Yojson.Basic.to_channel cout (yojson_of_value (to_json elt :> Json.value));
+           output_char cout '\n')
+    );
+    read_all = (fun ~filename ->
+      try
+        let entries = Yojson.Basic.stream_from_file filename in
+        let r = ref [] in
+        let of_yojson x =
+          match value_of_yojson x with
+          | #Json.t as x -> of_json x
+          | not_toplevel ->
+            Json.parse_error not_toplevel "Invalid toplevel JSON value"
+        in
+        Stream.iter (fun x -> r := of_yojson x :: !r) entries;
+        Ok (List.rev !r)
+      with Json.Parse_error (_, _) | Yojson.Json_error _ ->
+        Error (Printf.sprintf "In %s: json parsing error" filename)
+    );
+    write_all = (fun ~filename elts ->
+      let entries = List.map (fun elt ->
+        yojson_of_value (to_json elt :> Json.value)
+      ) elts
+      in
+      Yojson.Basic.stream_to_file filename
+        (Stream.of_list entries)
+    );
+  }
+
+(* *** *)
+
+type plain = Plain__
+type 'a append = Append__
+type ('a, 'k) file = File__
+type git = Git__
+type 'k dir = Dir__
+
+module type Spec = sig
+  val schema : fstree
+end
+
+module Make (Fs : Spec) = struct
+  type t = {
+    root : string;
+  }
+
+  let get_root db = db.root
+
+  let fsmkdir ?cap path =
+    let path' = OpamFilename.Dir.of_string path in
+    mkdir path';
+    match cap with
+    | Some { git = true } ->
+      (* do 'git init' if needed; otherwise cleanup uncommited modifications
+         (if any) *)
+      let open OpamProcess in
+      if not (OpamGit.VCS.exists path') then begin
+        let cmd = command ~dir:path "git" [ "init" ] in
+        run cmd |> must_succeed cmd
+      end;
+      begin match Job.run (OpamGit.VCS.revision path') with
+        | None -> (* no commits recorded *) ()
+        | Some _ ->
+          (* cleanup uncommited modifications *)
+          if Job.run (OpamGit.VCS.is_dirty path') then begin
+            Job.of_list [
+              command ~dir:path "git" [ "reset"; "--hard"; "HEAD" ];
+              command ~dir:path "git" [ "clean"; "-xfd" ];
+            ] |> Job.run
+            |> OpamStd.Option.iter (fun (cmd, res) -> must_succeed cmd res)
+          end
+      end
+    | Some { git = false } | None -> ()
+
+  let load ~root =
+    (* check that the filesystem corresponds to the provided schema, creating
+       directories/files with default values if needed. We then work with the
+       assumption that this property stays true for as long as we have hold of
+       the database handle. In other words, we assume that:
+
+       - there are no concurrent changes happening to the filesystem (while
+       marracheck is running);
+
+       - the filesystem is not updated by other means (without going through the
+       API) in a way that makes it inconsistent. *)
+    let rec loop (path: string) (tree: fstree) =
+      match tree with
+      | StaticDir { contents; cap } ->
+        fsmkdir ~cap path;
+        List.iter (fun (name, subtree) ->
+          loop (Filename.concat path name) subtree
+        ) contents
+      | DynDir { schema; cap } ->
+        fsmkdir ~cap path;
+        let contents = Sys.readdir path in
+        Array.iter (fun name ->
+          loop (Filename.concat path name) schema
+        ) contents
+      | ExtDir ->
+        fsmkdir path
+      | File { default; write; _ } ->
+        if not (Sys.file_exists path) then (
+          match default with
+          | Some v -> write ~filename:path v
+          | None -> fatal "%s required but not found" path
+        ) else if Sys.is_directory path then
+          fatal "%s exists but is not a file" path
+      | AppendFile { write_all; _ } ->
+        if not (Sys.file_exists path) then write_all ~filename:path []
+        else if Sys.is_directory path then
+          fatal "%s exists but is not a file" path
+    in
+    loop root Fs.schema;
+    { root }
+
+  type 'k path_desc =
+    | FilePath : 'a data_format -> ('a, plain) file path_desc
+    | AppendFilePath : 'a data_format -> ('a list, 'a append) file path_desc
+    | DirPath : plain dir path_desc
+    | GitDirPath : git dir path_desc
+
+  type 'k path = string list * 'k path_desc
+
+  exception Illegal_path of string list
+  let () =
+    Printexc.register_printer (fun exn ->
+      match exn with
+      | Illegal_path ps ->
+        Some (
+          Printf.sprintf "Illegal_path(%s)"
+            (List.fold_left Filename.concat "" ps)
+        )
+      | _ -> None
+    )
+
+  let subtree path (tree: fstree) : fstree =
+    let rec loop subpath tree =
+      match subpath with
+      | [] -> tree
+      | name :: subpath ->
+        match tree with
+        | File _ | AppendFile _ | ExtDir -> raise (Illegal_path path)
+        | StaticDir { contents; _ } ->
+          begin match List.assoc name contents with
+            | tree -> loop subpath tree
+            | exception Not_found -> raise (Illegal_path path)
+          end
+        | DynDir { schema; _ } ->
+          (* any name in this directory can be valid *)
+          loop subpath schema
+    in loop path tree
+
+  let check_path_against_schema : type a. a path -> unit = fun path ->
+    let path, path_desc = path in
+    let stree = subtree path Fs.schema in
+    match path_desc, stree with
+    | FilePath pformat, File { format; _ } ->
+      if data_format_eqbool format pformat then () else raise (Illegal_path path)
+    | (AppendFilePath pformat), (AppendFile { format; _ }) ->
+      if data_format_eqbool format pformat then () else raise (Illegal_path path)
+    | (GitDirPath | DirPath), (StaticDir _ | DynDir _ | ExtDir) ->
+      ()
+    | _, _ ->
+      raise (Illegal_path path)
+
+  let with_check_path_against_schema p =
+    check_path_against_schema p; p
+
+  let path desc p =
+    with_check_path_against_schema (p, desc)
+
+  let path_get_raw (p, _) = p
+
+  let string_of_path root (path: string list) =
+    List.fold_left Filename.concat root path
+
+  (* conservatively required when reading and appending. Writes that create the
+     file are ok. *)
+  let check_path_exists root (path: string list) =
+    let rec loop base path =
+      if not (Sys.file_exists base) then
+        fatal "%s does not exist" base;
+      match path with
+      | [] -> ()
+      | name :: path ->
+        if not (Sys.is_directory base) then
+          fatal "%s exists but is not a directory" base;
+        loop (Filename.concat base name) path
+    in
+    loop root path
+
+  let read : type a b. t -> (a, b) file path -> a =
+    fun db (path, desc) ->
+    let tree = subtree path Fs.schema in
+    check_path_exists db.root path;
+    let filename = string_of_path db.root path in
+    assert (Sys.file_exists filename && not (Sys.is_directory filename));
+    match tree, desc with
+    | File { format; read; _ }, FilePath pformat ->
+      (match read ~filename with
+       | Result.Ok x -> cast_data format pformat x
+       | Result.Error msg -> fatal "When reading %s: %s" filename msg)
+    | AppendFile { format; read_all; _ }, AppendFilePath pformat ->
+      begin match read_all ~filename with
+        | Result.Ok x -> cast_data_list format pformat x
+        | Result.Error msg -> fatal "When reading %s: %s" filename msg
+      end
+    | _ ->
+      raise (Illegal_path path)
+
+  let write : type a b. t -> (a, b) file path -> a -> unit =
+    fun db (path, desc) v ->
+    let tree = subtree path Fs.schema in
+    let filename = string_of_path db.root path in
+    match tree, desc with
+    | File { format; write; _ }, FilePath pformat ->
+      write ~filename (cast_data pformat format v)
+    | AppendFile { format; write_all; _ }, AppendFilePath pformat ->
+      write_all ~filename (cast_data_list pformat format v)
+    | _ ->
+      raise (Illegal_path path)
+
+  let append : type a b. t -> (a, b append) file path -> b -> unit =
+    fun db (path, desc) v ->
+    let tree = subtree path Fs.schema in
+    check_path_exists db.root path;
+    let filename = string_of_path db.root path in
+    match tree, desc with
+    | AppendFile { format; append; _ }, AppendFilePath pformat ->
+      append ~filename (cast_data pformat format v)
+    | _ ->
+      raise (Illegal_path path)
+
+  let commit db ?(msg = "-") (path, _) =
+    check_path_exists db.root path;
+    let dirname = string_of_path db.root path in
+    let msg = if msg = "" then "-" else msg in
+    let open OpamProcess in
+    Job.of_list [
+      command ~dir:dirname "git" [ "add"; "*"; ];
+      command ~dir:dirname "git" [ "commit"; "-a"; "--allow-empty"; "-m"; msg ];
+    ]
+    |> Job.run
+    |> OpamStd.Option.iter (fun (cmd, res) -> must_succeed cmd res)
+
+  let mkdir db (path, _desc) =
+    let tree = subtree path Fs.schema in
+    let dirname = string_of_path db.root path in
+    match tree with
+    | ExtDir -> fsmkdir dirname
+    | StaticDir { cap; _ } | DynDir { cap; _ } -> fsmkdir ~cap dirname
+    | _ -> raise (Illegal_path path)
+
+  let exists db (path, _) =
+    Sys.file_exists (string_of_path db.root path)
+end

--- a/lib/fs.mli
+++ b/lib/fs.mli
@@ -57,11 +57,11 @@ val appendfile_json :
 (* These types are used below in [Make.path_desc] as phantom types to describe
    the destination of a path in the filesystem.
 
-   The constructors (Plain__, etc) are never used to construct values, they are
-   only useful to help with GADT typechecking. *)
+   The user never needs to use the constructors (Plain__, etc), they are
+   only exposed to help with GADT typechecking. *)
 type plain = Plain__
 type 'a append = Append__
-type ('a, 'k) file = File__
+type ('a, 'k) file = File__ of 'a
 type git = Git__
 type 'k dir = Dir__
 
@@ -91,6 +91,12 @@ module Make (Fs : Spec) : sig
 
   val mkdir : t -> ?init:(unit -> unit) -> _ dir path -> unit
   val commit : t -> ?msg:string -> git dir path -> unit
+  val recreate : t ->
+    ?finalize:(unit -> unit) ->
+    ?init:(unit -> unit) ->
+    _ dir path ->
+    unit
 
+  val remove : t -> _ path -> unit
   val exists : t -> _ path -> bool
 end

--- a/lib/fs.mli
+++ b/lib/fs.mli
@@ -1,5 +1,9 @@
 open Utils
 
+(* Generic API for accessing (possibly serialized) data stored on the filesystem.
+   For the API specific to the marracheck on-disk data, see the [State] module.
+*)
+
 type _ data_format
 val mk_data_format : unit -> 'a data_format
 
@@ -50,7 +54,11 @@ val appendfile_json :
   of_json:(Json.t -> 'a) -> to_json:('a -> Json.t) ->
   fstree
 
-(* Used as phantom types; the constructors are never used *)
+(* These types are used below in [Make.path_desc] as phantom types to describe
+   the destination of a path in the filesystem.
+
+   The constructors (Plain__, etc) are never used to construct values, they are
+   only useful to help with GADT typechecking. *)
 type plain = Plain__
 type 'a append = Append__
 type ('a, 'k) file = File__
@@ -81,7 +89,7 @@ module Make (Fs : Spec) : sig
   val write : t -> ('a, _) file path -> 'a -> unit
   val append : t -> (_, 'b append) file path -> 'b -> unit
 
-  val mkdir : t -> _ dir path -> unit
+  val mkdir : t -> ?init:(unit -> unit) -> _ dir path -> unit
   val commit : t -> ?msg:string -> git dir path -> unit
 
   val exists : t -> _ path -> bool

--- a/lib/fs.mli
+++ b/lib/fs.mli
@@ -1,0 +1,88 @@
+open Utils
+
+type _ data_format
+val mk_data_format : unit -> 'a data_format
+
+type dircap = { git : bool }
+
+(* schema describing an in-filesystem layout *)
+type fstree =
+  | StaticDir : {
+      contents : (string * fstree) list;
+      cap : dircap;
+    } -> fstree
+
+  | DynDir : {
+      schema : fstree;
+      cap : dircap;
+    } -> fstree
+
+  | ExtDir : fstree
+
+  | File : {
+      format : 'a data_format;
+      (* if not None, used to create the file if the file does not exist. if
+         None and the file does not exist, then the db is in a "broken" state
+         and an error is raised *)
+      default : 'a option;
+      write : filename:string -> 'a -> unit;
+      read : filename:string -> ('a, string) Result.t;
+    } -> fstree
+
+  | AppendFile : {
+      format : 'a data_format;
+      append : filename:string -> 'a -> unit;
+      read_all : filename:string -> ('a list, string) Result.t;
+      write_all : filename:string -> 'a list -> unit;
+    } -> fstree
+
+(* fstree helpers for building File/AppendFile nodes *)
+val file_raw :
+  format:string data_format -> default:string option -> fstree
+
+val file_json :
+  format:'a data_format -> default:'a option ->
+  of_json:(Json.t -> 'a) -> to_json:('a -> Json.t) ->
+  fstree
+
+val appendfile_json :
+  format:'a data_format ->
+  of_json:(Json.t -> 'a) -> to_json:('a -> Json.t) ->
+  fstree
+
+(* Used as phantom types; the constructors are never used *)
+type plain = Plain__
+type 'a append = Append__
+type ('a, 'k) file = File__
+type git = Git__
+type 'k dir = Dir__
+
+module type Spec = sig
+  val schema : fstree
+end
+
+module Make (Fs : Spec) : sig
+  type t
+  val load : root:string -> t
+  val get_root : t -> string
+
+  type _ path_desc =
+    | FilePath : 'a data_format -> ('a, plain) file path_desc
+    | AppendFilePath : 'a data_format -> ('a list, 'a append) file path_desc
+    | DirPath : plain dir path_desc
+    | GitDirPath : git dir path_desc
+  type 'k path
+
+  exception Illegal_path of string list
+  val path : 'k path_desc -> string list -> 'k path
+  val path_get_raw : _ path -> string list
+
+  val read : t -> ('a, _) file path -> 'a
+  val write : t -> ('a, _) file path -> 'a -> unit
+  val append : t -> (_, 'b append) file path -> 'b -> unit
+
+  val mkdir : t -> _ dir path -> unit
+  val commit : t -> ?msg:string -> git dir path -> unit
+
+  val exists : t -> _ path -> bool
+end

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -3,11 +3,11 @@ open Utils
 (* Definition of the schema *)
 
 module Fmt = struct
-  let raw = Fs.mk_data_format ()
-  let cover = Fs.mk_data_format ()
-  let cover_elt_plan_opt = Fs.mk_data_format ()
-  let package_report = Fs.mk_data_format ()
-  let pkg_set = Fs.mk_data_format ()
+  let raw : string Fs.data_format = Fs.mk_data_format ()
+  let cover : Data.Cover.t Fs.data_format = Fs.mk_data_format ()
+  let cover_elt_plan_opt : Lib.Cover_elt_plan.t option Fs.data_format = Fs.mk_data_format ()
+  let package_report : Data.Package_report.t Fs.data_format = Fs.mk_data_format ()
+  let pkg_set : PkgSet.t Fs.data_format = Fs.mk_data_format ()
 end
 
 (* NOTE: this is not a recursive definition; the 'rec'/'and' are used to write

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -1,462 +1,198 @@
-open OpamTypes
 open Utils
 
-module Cover_elt_plan = Lib.Cover_elt_plan
+(* Definition of the schema *)
 
-(* Relative to the workdir *)
-let cache_path = "cache"
-let switches_path = "switches"
-let opamroot_path = "opamroot"
-
-(* Relative to a switch_state directory *)
-let log_path = "log"
-let cover_state_repo_path = "cover_state.git"
-let past_timestamps_path = "past_timestamps"
-
-(* Relative to a cover_state.git directory *)
-let timestamp_path = "timestamp"
-let past_elts_path = "past_elts.json"
-let cur_plan_path = "cur_plan.json"
-let cur_report_path = "cur_report.json"
-let uninst_path = "uninst.json"
-
-module Repo = struct
-  type 'a t = {
-    head : 'a option;
-    path : dirname;
-  }
-
-  let load_and_clean
-      ~(path : dirname)
-      ~(load : dir:dirname -> 'a)
-    : 'a t =
-    let open OpamProcess in
-    let path_s = OpamFilename.Dir.to_string path in
-    mkdir path;
-    if not (OpamGit.VCS.exists path) then begin
-      let cmd = command ~dir:path_s "git" [ "init" ] in
-      run cmd |> must_succeed cmd
-    end;
-    match Job.run (OpamGit.VCS.revision path) with
-    | None ->
-      (* No commits recorded *)
-      { path; head = None }
-    | Some _ ->
-      (* cleanup uncommited modifications *)
-      if Job.run (OpamGit.VCS.is_dirty path) then begin
-        Job.of_list [
-          command ~dir:path_s "git" [ "reset"; "--hard"; "HEAD" ];
-          command ~dir:path_s "git" [ "clean"; "-xfd" ];
-        ] |> Job.run
-        |> OpamStd.Option.iter (fun (cmd, res) -> must_succeed cmd res)
-      end;
-      { path; head = Some (load ~dir:path) }
-
-  let commit_new_head ~(sync : 'a -> 'a) msg (st: 'a t) : 'a t =
-    let open OpamProcess in
-    let path_s = OpamFilename.Dir.to_string st.path in
-    match st.head with
-    | None -> assert false
-    | Some data ->
-      let data = sync data in
-      let msg = if msg = "" then "-" else msg in
-      let () =
-        Job.of_list [
-          command ~dir:path_s "git" [ "add"; "*"; ];
-          command ~dir:path_s "git" [ "commit"; "-a"; "--allow-empty"; "-m"; msg ];
-        ]
-        |> Job.run
-        |> OpamStd.Option.iter (fun (cmd, res) -> must_succeed cmd res)
-      in
-      { st with head = Some data }
+module Fmt = struct
+  let raw = Fs.mk_data_format ()
+  let cover = Fs.mk_data_format ()
+  let cover_elt_plan_opt = Fs.mk_data_format ()
+  let package_report = Fs.mk_data_format ()
+  let pkg_set = Fs.mk_data_format ()
 end
 
-module Serialized = struct
-  type 'a t = {
-    data : 'a;
-    path : filename;
+(* NOTE: this is not a recursive definition; the 'rec'/'and' are used to write
+   declarations in reverse order (which is more natural here). *)
+let rec fs =
+  Fs.StaticDir {
+    cap = { git = false };
+    contents = [
+      "cache", ExtDir;
+      "switches", DynDir {
+        cap = { git = false };
+        schema = switch_state;
+      };
+      "opamroot", ExtDir;
+    ]
   }
 
-  let load_raw ~file : string t =
-    { data = OpamSystem.read (OpamFilename.to_string file);
-      path = file }
-
-  let sync_raw (s : string t) : string t =
-    OpamSystem.write (OpamFilename.to_string s.path) s.data;
-    s
-
-  let load_json ~file (of_json : Json.value -> 'a) : 'a t =
-    let j = read_json file in
-    let j = Json.value j in
-    { data = of_json j; path = file }
-
-  let sync_json (s : 'a t) (to_json : 'a -> Json.t) : 'a t =
-    let cout = open_out (OpamFilename.to_string s.path) in
-    Json.to_channel ~minify:false cout (to_json s.data);
-    close_out cout;
-    s
-end
-
-module SerializedLog = struct
-  type 'a t = {
-    old_data : 'a list;
-    new_data : 'a list;
-    path : filename;
+and switch_state =
+  Fs.StaticDir {
+    cap = { git = false };
+    contents = [
+      "cover_state.git", cover_state;
+      "past_timestamps", ExtDir;
+    ]
   }
 
-  let items t =
-    List.rev_append t.new_data t.old_data
-
-  let add_item item t =
-    { t with new_data = item :: t.new_data }
-
-  let add_items items t =
-    { t with new_data = List.rev_append items t.new_data }
-
-  let load_json ~file (of_json: Json.t -> 'a): 'a t =
-    let data =
-      let entries = Yojson.Basic.stream_from_file (OpamFilename.to_string file) in
-      let r = ref [] in
-      let of_yojson x =
-        match value_of_yojson x with
-          | #Json.t as x -> of_json x
-          | not_toplevel ->
-             fatal "Invalid toplevel JSON value in %S:\n%s"
-               (OpamFilename.to_string file)
-               (Json.value_to_string not_toplevel)
-      in
-      Stream.iter (fun x -> r := of_yojson x :: !r) entries;
-      List.rev !r
-    in
-    {
-      old_data = data;
-      new_data = [];
-      path = file;
-    }
-
-  let sync_json (type a) (t : a t) (to_json: a -> Json.t): a t =
-    CCIO.with_out_a (OpamFilename.to_string t.path) (fun chan ->
-      let ppf = Format.formatter_of_out_channel chan in
-      List.iter (fun item ->
-          Format.fprintf ppf "%a@."
-            (Yojson.Basic.pretty_print ?std:None)
-            (yojson_of_value (to_json item :> Json.value)))
-        (List.rev t.new_data));
-    {
-      old_data = items t;
-      new_data = [];
-      path = t.path;
-    }
-end
-
-type timestamp = string (* git hash *)
-type build_log = string list
-type changes = Changes (* fixme *)
-type error_cause = [ `Fetch | `Build | `Install ]
-
-type package_report =
-  | Success of { log : build_log; changes : changes }
-  | Error of { log : build_log; cause : error_cause }
-  | Aborted of { deps : Action.Set.t }
-  (* An [Aborted] status means that the package could not be built
-     because _for all possible ways of building the package_
-     at least one of its dependencies fails to build. *)
-
-let package_report_of_json (j: Json.value): package_report =
-  let l = Json.get_dict j in
-  try
-    begin match Json.get_string (List.assoc "status" l) with
-    | "success" ->
-      Success { log = Json.get_list Json.get_string (List.assoc "log" l);
-                changes = Changes (* TODO *) }
-    | "error" ->
-      let cause = match Json.get_string (List.assoc "cause" l) with
-        | "fetch" -> `Fetch
-        | "build" -> `Build
-        | "install" -> `Install
-        | _ -> raise Not_found
-      in
-      Error { log = Json.get_list Json.get_string (List.assoc "log" l); cause }
-    | "aborted" ->
-      let deps = match Action.Set.of_json (List.assoc "deps" l) with
-        | Some deps -> deps
-        | None -> raise Not_found
-      in
-      Aborted { deps }
-    | _ -> raise Not_found
-    end
-  with Not_found -> Json.parse_error `Null "" (* XX *)
-
-let package_report_to_json = function
-  | Success { log; changes = Changes (* TODO *) } ->
-    `O [ ("status", `String "success");
-         ("log", Json.strings log) ]
-  | Error { log; cause } ->
-    let cause_s = match cause with
-      | `Fetch -> "fetch"
-      | `Build -> "build"
-      | `Install -> "install"
-    in
-    `O [ ("status", `String "error");
-         ("log", Json.strings log);
-         ("cause", `String cause_s) ]
-  | Aborted { deps } ->
-    `O [ ("status", `String "aborted");
-         ("deps", Action.Set.to_json deps) ]
-
-module Cover = struct
-  type elt_report = package_report OpamPackage.Map.t
-  type elt = Cover_elt_plan.t * elt_report
-  type t = elt list
-
-  let cover_elt_plan_of_json (j: Json.value): Cover_elt_plan.t =
-    try
-      let l = Json.get_dict j in
-      let get_opt = function Some x -> x | None -> raise Not_found in
-      { solution =
-          OpamSolver.solution_of_json (List.assoc "solution" l)
-          |> get_opt;
-        useful =
-          PkgSet.of_json (List.assoc "useful" l) |> get_opt; }
-    with Not_found -> Json.parse_error j "invalid cover element"
-
-  let cover_elt_plan_to_json plan =
-    `O [ ("solution", OpamSolver.solution_to_json plan.Cover_elt_plan.solution);
-         ("useful", PkgSet.to_json plan.Cover_elt_plan.useful) ]
-
-  let cover_elt_report_of_json (j : Json.value): elt_report =
-    let report_of_json j = Some (package_report_of_json j) in
-    match OpamPackage.Map.of_json report_of_json j with
-    | Some r -> r
-    | None -> Json.parse_error j "invalid cover report"
-
-  let cover_elt_report_to_json (report: elt_report) =
-    OpamPackage.Map.to_json package_report_to_json report
-
-  let elt_of_json (j: Json.value): elt =
-    Json.get_pair cover_elt_plan_of_json cover_elt_report_of_json j
-
-  let elt_to_json (elt: elt): Json.value =
-    Json.pair cover_elt_plan_to_json cover_elt_report_to_json elt
-
-  let of_json (j: Json.value): t =
-    Json.get_list elt_of_json j
-
-  let to_json (cover : t): Json.t =
-    Json.list elt_to_json cover
-end
-
-module Cover_state = struct
-  type report_item = OpamPackage.t * package_report
-
-  type t = {
-    timestamp : timestamp Serialized.t;
-    past_elts : Cover.t Serialized.t;
-    cur_plan : Cover_elt_plan.t option Serialized.t;
-    cur_report : report_item SerializedLog.t;
-    uninst: OpamPackage.Set.t Serialized.t;
+and cover_state =
+  Fs.StaticDir {
+    cap = { git = true };
+    contents = [
+      "timestamp",
+      Fs.file_raw ~format:Fmt.raw ~default:None
+      ;
+      "past_elts.json",
+      Fs.file_json ~format:Fmt.cover
+        ~default:(Some [])
+        ~of_json:Data.Cover.of_json
+        ~to_json:Data.Cover.to_json
+      ;
+      "cur_plan.json",
+      Fs.file_json ~format:Fmt.cover_elt_plan_opt
+        ~default:(Some None)
+        ~of_json:Data.Cover_elt_plan.opt_of_json
+        ~to_json:Data.Cover_elt_plan.opt_to_json
+      ;
+      "cur_report.json",
+      Fs.appendfile_json ~format:Fmt.package_report
+        ~of_json:Data.Package_report.of_json
+        ~to_json:Data.Package_report.to_json
+      ;
+      "uninst.json",
+      Fs.file_json ~format:Fmt.pkg_set
+        ~default:(Some PkgSet.empty)
+        ~of_json:Data.Uninst.of_json
+        ~to_json:Data.Uninst.to_json
+      ;
+    ]
   }
 
-  let nonbuilt_useful_packages plan report =
-    List.fold_left
-      (fun set (package, _) -> PkgSet.remove package set)
-      plan.Cover_elt_plan.useful
-      report
+(* paths *)
 
-  let broken_packages st =
-    let select_broken (pkg, report) =
-      match report with
-      | Error _ -> Some pkg
-      | Success _ | Aborted _ -> None in
-    let elt_broken (_sol, report) =
-      PkgMap.to_seq report
-      |> Seq.filter_map select_broken
-      |> PkgSet.of_seq
-    in
-    let cur_broken =
-      CCList.filter_map select_broken (SerializedLog.items st.cur_report)
-      |> PkgSet.of_list in
-    List.fold_left
-      (fun set elt -> PkgSet.union set (elt_broken elt))
-      cur_broken st.past_elts.data
+module Db = Fs.Make(struct let schema = fs end)
 
-  (* we want the *resolved* packages: succeeded, failed, and uninstallable *)
-  let select_resolved (pkg, report) =
+type t = Db.t
+type plain = Fs.plain
+type 'a append = 'a Fs.append
+type ('a, 'k) file = ('a, 'k) Fs.file
+type git = Fs.git
+type 'k dir = 'k Fs.dir
+type 'k path = 'k Db.path
+
+let load ~workdir = Db.load ~root:workdir
+let get_workdir = Db.get_root
+let read = Db.read
+let write = Db.write
+let append = Db.append
+let commit = Db.commit
+let mkdir = Db.mkdir
+let exists = Db.exists
+
+let p ~workdir path =
+  List.fold_left Filename.concat workdir @@
+  Db.path_get_raw path
+
+let d ~workdir path =
+  OpamFilename.Dir.of_string (p ~workdir path)
+
+let f ~workdir path =
+  OpamFilename.of_string (p ~workdir path)
+
+let cache_path =
+  Db.path DirPath ["cache"]
+
+let opamroot_path =
+  Db.path DirPath ["opamroot"]
+
+let past_timestamps_path ~switch =
+  Db.path DirPath ["switches"; switch; "past_timestamps"]
+
+let cover_state_path ~switch =
+  Db.path GitDirPath ["switches"; switch; "cover_state.git"]
+
+let timestamp_path ~switch =
+  Db.path (FilePath Fmt.raw)
+    ["switches"; switch; "cover_state.git"; "timestamp"]
+
+let past_elts_path ~switch =
+  Db.path (FilePath Fmt.cover)
+    ["switches"; switch; "cover_state.git"; "past_elts.json"]
+
+let cur_plan_path ~switch =
+  Db.path (FilePath Fmt.cover_elt_plan_opt)
+    ["switches"; switch; "cover_state.git"; "cur_plan.json"]
+
+let cur_report_path ~switch =
+  Db.path (AppendFilePath Fmt.package_report)
+    ["switches"; switch; "cover_state.git"; "cur_report.json"]
+
+let uninst_path ~switch =
+  Db.path (FilePath Fmt.pkg_set)
+    ["switches"; switch; "cover_state.git"; "uninst.json"]
+
+(* higher-level queries *)
+
+let nonbuilt_useful_packages db ~switch plan =
+  List.fold_left
+    (fun set (package, _) -> PkgSet.remove package set)
+    plan.Lib.Cover_elt_plan.useful
+    (Db.read db @@ cur_report_path ~switch)
+
+(* we want the *resolved* packages: succeeded, failed, and uninstallable *)
+let select_resolved (pkg, report) =
+  match report with
+  | Data.Package_report.Success _ | Error _ -> Some pkg
+  | Aborted _ -> None
+
+let past_resolved_packages db ~switch =
+  let resolved report =
+    PkgMap.to_seq report
+    |> Seq.filter_map select_resolved
+    |> PkgSet.of_seq
+  in
+  List.fold_left (fun set (_, report) -> PkgSet.union set (resolved report))
+    (Db.read db (uninst_path ~switch))
+    (Db.read db (past_elts_path ~switch))
+
+let resolved_packages db ~switch =
+  let cur_resolved =
+    Db.read db (cur_report_path ~switch)
+    |> CCList.filter_map select_resolved
+    |> PkgSet.of_list
+  in
+  PkgSet.union cur_resolved (past_resolved_packages db ~switch)
+
+let broken_packages db ~switch =
+  let select_broken (pkg, report) =
     match report with
-      | Success _ | Error _ -> Some pkg
-      | Aborted _ -> None
+    | Data.Package_report.Error _ -> Some pkg
+    | Success _ | Aborted _ -> None in
+  let elt_broken (_sol, report) =
+    PkgMap.to_seq report
+    |> Seq.filter_map select_broken
+    |> PkgSet.of_seq
+  in
+  let cur_broken =
+    CCList.filter_map select_broken (Db.read db (cur_report_path ~switch))
+    |> PkgSet.of_list in
+  List.fold_left
+    (fun set elt -> PkgSet.union set (elt_broken elt))
+    cur_broken
+    (Db.read db (past_elts_path ~switch))
 
-  let past_resolved_packages st =
-    let resolved report =
-      PkgMap.to_seq report
-      |> Seq.filter_map select_resolved
-      |> PkgSet.of_seq
-    in
-    List.fold_left
-      (fun set (_elt, report) -> PkgSet.union set (resolved report))
-      st.uninst.data
-      st.past_elts.data
+let map_of_report report =
+  List.fold_left (fun map (package, package_report) ->
+    PkgMap.add package package_report map
+  ) PkgMap.empty report
 
-  let resolved_packages st =
-    let cur_resolved =
-      SerializedLog.items st.cur_report
-      |> List.to_seq
-      |> Seq.filter_map select_resolved
-      |> PkgSet.of_seq
-    in
-    PkgSet.union cur_resolved (past_resolved_packages st)
-
-  let create ~dir ~timestamp =
-    let open OpamFilename in
-    { timestamp = { data = timestamp; path = Op.(dir // timestamp_path) };
-      past_elts = { data = []; path = Op.(dir // past_elts_path) };
-      cur_plan = { data = None; path = Op.(dir // cur_plan_path) };
-      cur_report = { old_data = []; new_data = []; path = Op.(dir // cur_report_path) };
-      uninst = { data = PkgSet.empty; path = Op.(dir // uninst_path) };
-    }
-
-  let archive_report report =
-    List.fold_left (fun archive (package, package_report) ->
-        PkgMap.add package package_report archive
-      ) PkgMap.empty report
-
-  let archive_cur_elt (st: t): Cover.elt * t =
-    match st.cur_plan.data with
-    | None -> assert false
-    | Some plan ->
-      let report = archive_report (SerializedLog.items st.cur_report) in
-      let elt = (plan, report) in
-      elt,
-      { st with
-        past_elts = { st.past_elts with data = elt :: st.past_elts.data };
-        cur_plan = { data = None; path = st.cur_plan.path };
-        cur_report = { old_data = []; new_data = []; path = st.cur_report.path };
-      }
-
-  let add_item_to_report item (st: t): t =
-    { st with cur_report = SerializedLog.add_item item st.cur_report }
-
-  let add_items_to_report items (st: t): t =
-    { st with cur_report = SerializedLog.add_items items st.cur_report }
-
-  (* This assumes that the files already exist on the filesystem in a valid
-     state *)
-  let load ~dir : t =
-    let open OpamFilename in
-    let assoc k l =
-      try List.assoc k l with Not_found ->
-        Json.parse_error `Null "" (* XX *) in
-    let get_opt =
-      function Some x -> x | None -> Json.parse_error `Null "" (* XX *) in
-    let report_item_of_json j =
-      let j = Json.value j in
-      let l = Json.get_dict j in
-      let pkg = assoc "package" l in
-      let pkg_report = assoc "report" l in
-      (get_opt (OpamPackage.of_json pkg),
-       package_report_of_json pkg_report)
-    in
-    let cur_elt_plan_of_json j =
-      match j with
-      | `A [] -> None
-      | `A [ j' ] -> Some (Cover.cover_elt_plan_of_json j')
-      | _ ->
-        fatal "In %s: invalid format"
-          OpamFilename.(prettify Op.(dir // cur_plan_path))
-    in
-    let uninst_of_json j =
-      get_opt (PkgSet.of_json (Json.get_dict j |> assoc "uninst")) in
-    {
-      timestamp = Serialized.load_raw ~file:Op.(dir // timestamp_path);
-      past_elts = Serialized.load_json ~file:Op.(dir // past_elts_path) Cover.of_json;
-      cur_plan =
-        Serialized.load_json ~file:Op.(dir // cur_plan_path) cur_elt_plan_of_json;
-      cur_report =
-        SerializedLog.load_json ~file:Op.(dir // cur_report_path) report_item_of_json;
-      uninst = Serialized.load_json ~file:Op.(dir // uninst_path) uninst_of_json;
-    }
-
-  let sync state : t =
-    let report_item_to_json (pkg, pkg_report) =
-      `O [ ("package", OpamPackage.to_json pkg);
-           ("report", package_report_to_json pkg_report) ]
-    in
-    let cur_plan_to_json = function
-      | None -> `A []
-      | Some elt -> `A [ Cover.cover_elt_plan_to_json elt ] in
-    let uninst_to_json set = `O [ "uninst", PkgSet.to_json set ] in
-
-    let timestamp = Serialized.sync_raw state.timestamp in
-    let past_elts = Serialized.sync_json state.past_elts Cover.to_json in
-    let cur_plan = Serialized.sync_json state.cur_plan cur_plan_to_json in
-    let cur_report = SerializedLog.sync_json state.cur_report report_item_to_json in
-    let uninst = Serialized.sync_json state.uninst uninst_to_json in
-    { timestamp; past_elts; cur_plan; cur_report; uninst }
-end
-
-module Switch_state = struct
-  type t = {
-    path : dirname;
-    log : filename;
-    cover_state_repo : Cover_state.t Repo.t;
-    past_timestamps : dirname;
-  }
-end
-
-module Work_state = struct
-  type 'a t = {
-    opamroot : dirname;
-    cache : dirname;
-    switches : dirname;
-    view : 'a;
-  }
-
-  module View_single = struct
-    type t = Switch_state.t
-    let load_or_create (compiler:package) ~workdir : t =
-      let open OpamFilename in
-      let switch_dir =
-        Op.(workdir / switches_path / OpamPackage.to_string compiler) in
-      mkdir switch_dir;
-      mkdir Op.(switch_dir / cover_state_repo_path);
-      mkdir Op.(switch_dir / past_timestamps_path);
-      let cover_state_repo =
-        Repo.load_and_clean
-          ~path:Op.(switch_dir / cover_state_repo_path)
-          ~load:Cover_state.load
-      in
-      { path = switch_dir;
-        log = Op.(switch_dir // log_path);
-        cover_state_repo;
-        past_timestamps = Op.(switch_dir / past_timestamps_path); }
-
-    let sync ~workdir state =
-      let _ = workdir, state in assert false
-  end
-
-  module View_all = struct
-    type t = Switch_state.t PkgMap.t
-    let load ~workdir : t =
-      (* load all things that resemble valid switch states;
-         errors for any directory that exists in switches/
-         but is not valid *)
-      let _ = workdir in assert false
-    let sync ~workdir state =
-      let _ = workdir, state in assert false
-  end
-
-  let load_or_create ~(view : workdir:dirname -> 'view) ~workdir : 'view t =
-    let open OpamFilename in
-    mkdir workdir;
-    (* workdir / opamroot_path will be created automatically by the opam
-       initialization code. *)
-    mkdir Op.(workdir / cache_path);
-    mkdir Op.(workdir / switches_path);
-    { opamroot = Op.(workdir / opamroot_path);
-      cache = Op.(workdir / cache_path);
-      switches = Op.(workdir / switches_path);
-      view = view ~workdir }
-
-  let sync ~(view : workdir:dirname -> 'view -> unit) ~workdir : unit =
-    let _ = (view, workdir) in assert false
-end
+let archive_cur_elt db ~switch =
+  match Db.read db (cur_plan_path ~switch) with
+  | None -> None
+  | Some plan ->
+    let report = map_of_report (Db.read db (cur_report_path ~switch)) in
+    let elt = (plan, report) in
+    let past_elts = Db.read db (past_elts_path ~switch) in
+    Db.write db (past_elts_path ~switch) (elt :: past_elts);
+    Db.write db (cur_plan_path ~switch) None;
+    Db.write db (cur_report_path ~switch) [];
+    Some elt

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -85,7 +85,9 @@ let read = Db.read
 let write = Db.write
 let append = Db.append
 let commit = Db.commit
+let recreate = Db.recreate
 let mkdir = Db.mkdir
+let remove = Db.remove
 let exists = Db.exists
 
 let p ~workdir path =

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -1,0 +1,48 @@
+open Utils
+
+type t
+val load : workdir:string -> t
+val get_workdir : t -> string
+
+type plain
+type 'a append
+type ('a, 'k) file
+type git
+type 'k dir
+type 'k path
+
+val read : t -> ('a, _) file path -> 'a
+val write : t -> ('a, _) file path -> 'a -> unit
+val append : t -> (_, 'b append) file path -> 'b -> unit
+
+val mkdir : t -> _ dir path -> unit
+val commit : t -> ?msg:string -> git dir path -> unit
+
+val exists : t -> _ path -> bool
+
+(* converting paths to full filesystem paths *)
+
+val p : workdir:string -> _ path -> string
+val d : workdir:string -> _ dir path -> OpamTypes.dirname
+val f : workdir:string -> _ file path -> OpamTypes.filename
+
+(* path constructors *)
+
+val cache_path : plain dir path
+val opamroot_path : plain dir path
+(* switch_state-local paths *)
+val past_timestamps_path : switch:string -> plain dir path
+val cover_state_path : switch:string -> git dir path
+val timestamp_path : switch:string -> (string, plain) file path
+val past_elts_path : switch:string -> (Data.Cover.t, plain) file path
+val cur_plan_path : switch:string -> (Data.Cover_elt_plan.t option, plain) file path
+val cur_report_path : switch:string -> (Data.Package_report.t list, Data.Package_report.t append) file path
+val uninst_path : switch:string -> (PkgSet.t, plain) file path
+
+(* higher-level queries that aggregate or further process information from the
+   files *)
+
+val resolved_packages : t -> switch:string -> PkgSet.t
+val broken_packages : t -> switch:string -> PkgSet.t
+val nonbuilt_useful_packages : t -> switch:string -> Data.Cover_elt_plan.t -> PkgSet.t
+val archive_cur_elt : t -> switch:string -> Data.Cover.elt option

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -17,7 +17,13 @@ val append : t -> (_, 'b append) file path -> 'b -> unit
 
 val mkdir : t -> ?init:(unit -> unit) -> _ dir path -> unit
 val commit : t -> ?msg:string -> git dir path -> unit
+val recreate : t ->
+  ?finalize:(unit -> unit) ->
+  ?init:(unit -> unit) ->
+  _ dir path ->
+  unit
 
+val remove : t -> _ path -> unit
 val exists : t -> _ path -> bool
 
 (* converting paths to full filesystem paths *)

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -15,7 +15,7 @@ val read : t -> ('a, _) file path -> 'a
 val write : t -> ('a, _) file path -> 'a -> unit
 val append : t -> (_, 'b append) file path -> 'b -> unit
 
-val mkdir : t -> _ dir path -> unit
+val mkdir : t -> ?init:(unit -> unit) -> _ dir path -> unit
 val commit : t -> ?msg:string -> git dir path -> unit
 
 val exists : t -> _ path -> bool

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -39,9 +39,13 @@ let log fmt =
   Format.fprintf Format.err_formatter "LOG %a: " timestamp ();
   Format.fprintf Format.err_formatter (fmt ^^ "\n%!")
 
+exception Fatal
+
+(* raising [Fatal] instead of calling [exit 1] so that we get a backtrace when
+   running with OCAMLRUNPARAM=b. *)
 let fatal fmt =
   Format.fprintf Format.err_formatter "ERROR %a: " timestamp ();
-  Format.kfprintf (fun _ -> exit 1) Format.err_formatter (fmt ^^ "\n%!")
+  Format.kfprintf (fun _ -> raise Fatal) Format.err_formatter (fmt ^^ "@.")
 
 let mkdir dir =
   let dir = OpamFilename.Dir.to_string dir in

--- a/marracheck.opam
+++ b/marracheck.opam
@@ -24,6 +24,7 @@ depends: [
   "ezjsonm" {>= "1.1.0"}
   "yojson"
   "lwt"
+  "dmap"
 #  "z3" {>= "4.8.4"}
   "opam-file-format" {= "2.1.3"}
 #

--- a/marracheck.opam
+++ b/marracheck.opam
@@ -20,7 +20,7 @@ depends: [
   "bos"
   "oseq"
   "containers" {>= "3.6"}
-  "cmdliner"
+  "cmdliner" {< "1.1.0"}
   "ezjsonm" {>= "1.1.0"}
   "yojson"
   "lwt"

--- a/src/marracheck.ml
+++ b/src/marracheck.ml
@@ -478,25 +478,12 @@ let recover_switch_state
     log "Initialize a fresh cover state";
     (* This initializes a fresh cover_state repository; it contains
        no data at this point *)
-    State.(mkdir st @@ cover_state_path ~switch);
-    (* Initialize the directory. *)
-    (* NOTE: we need to provide the timestamp explicitly, but for the rest we
-       could have an [autoinit] function that would initialize the rest using
-       the default values from the schema.
-
-       Alternatively, we could make it so [State.read] auto-creates files
-       using default values when trying to read from a file that does not
-       exist (currently this auto-creation is only done once by [State.load]).
-       However this becomes a bit tricky if one needs to do it in depth and
-       create directories...
-
-       For now it seems simpler to require that when one creates a directory,
-       one manually initializes it so that it satisfies the schema. *)
-    State.(write st @@ timestamp_path ~switch) repo_timestamp;
-    State.(write st @@ past_elts_path ~switch) [];
-    State.(write st @@ cur_plan_path ~switch) None;
-    State.(write st @@ cur_report_path ~switch) [];
-    State.(write st @@ uninst_path ~switch) PkgSet.empty;
+    State.mkdir st (State.cover_state_path ~switch) ~init:(fun () ->
+      (* Initialize the directory. We need to provide the timestamp
+         explicitly; the other files will be generated automatically from
+         their default value following the schema. *)
+      State.(write st @@ timestamp_path ~switch) repo_timestamp
+    );
     State.(commit st ~msg:"Initial cover state" @@ cover_state_path ~switch)
   end
 

--- a/src/marracheck.ml
+++ b/src/marracheck.ml
@@ -626,13 +626,20 @@ let build
   start_build ~universe ~to_install
 
 let run_cmd ~repo_url ~working_dir ~compiler_variant ~package_selection =
+  (* resolve workdir as an absolute path *)
+  let workdir =
+    if Filename.is_relative working_dir then
+      Filename.concat (Sys.getcwd ()) working_dir
+    else
+      working_dir
+  in
+
   (* create [working_dir] if it does not exist *)
   mkdir (Dir.of_string working_dir);
 
   (* Create a state handle for the workdir, checking that it conforms to the
      expected schema, creating directories/files with default values if needed
      *)
-  let workdir = working_dir in
   let st = State.load ~workdir in
 
   let compiler = get_or_fatal (validate_compiler_variant compiler_variant)

--- a/src/marracheck.ml
+++ b/src/marracheck.ml
@@ -2,7 +2,6 @@ open Marracheck_lib
 open OpamTypes
 module ST = OpamStateTypes
 open Utils
-open State
 module File = OpamFilename
 module Dir = OpamFilename.Dir
 module PkgSet = OpamPackage.Set
@@ -151,11 +150,6 @@ let switch_universe () =
   OpamSwitchState.with_ `Lock_read gt @@ fun sw ->
   universe ~sw
 
-let validate_workdir working_dir =
-  let workdir = Dir.of_string working_dir in
-  mkdir workdir;
-  Some workdir
-
 let validate_compiler_variant s =
   let open OpamPackage in
   match of_string_opt s with
@@ -189,15 +183,15 @@ let get_repo_timestamp (repo_url: OpamUrl.t) =
        one commit in the repo. *)
     assert false
 
-let create_new_switch gt ~switch_name ~compiler =
-  log "Creating a new switch %s..." (OpamSwitch.to_string switch_name);
+let create_new_switch gt ~switch ~compiler =
+  log "Creating a new switch %s..." (OpamSwitch.to_string switch);
   let ((), sw) =
     OpamRepositoryState.with_ `Lock_none gt @@ begin fun rt ->
       (* setup a new switch with [compiler_variant] as compiler *)
       OpamSwitchCommand.create gt ~rt
         ~update_config:true
         ~invariant:(OpamFormula.of_conjunction [compiler.name, Some (`Eq, compiler.version)])
-        switch_name
+        switch
         (fun sw -> (), OpamSwitchCommand.install_compiler sw)
     end in
   log "New switch successfully created";
@@ -205,12 +199,12 @@ let create_new_switch gt ~switch_name ~compiler =
      updated! (to contain the newly created switch) *)
   sw, sw.switch_global
 
-let remove_switch gt ~switch_name =
-  OpamSwitchCommand.remove gt ~confirm:false switch_name
+let remove_switch gt ~switch =
+  OpamSwitchCommand.remove gt ~confirm:false switch
 
-let recreate_switch gt ~switch_name ~compiler =
-  let gt = remove_switch gt ~switch_name in
-  let sw, gt = create_new_switch gt ~switch_name ~compiler in
+let recreate_switch gt ~switch ~compiler =
+  let gt = remove_switch gt ~switch in
+  let sw, gt = create_new_switch gt ~switch ~compiler in
   OpamSwitchState.unlock sw, gt
 
 let build_log_of_exn exn =
@@ -236,9 +230,10 @@ let build_log_of_exn exn =
 let process_package_result
     (action : package action)
     (action_result : (PkgSet.t * PkgSet.t, OpamSolver.Action.Set.t) action_result)
-  : Cover_state.report_item option
+  : Data.Package_report.t option
   =
-  let error exn cause = Error { log = build_log_of_exn exn; cause } in
+  let module R = Data.Package_report in
+  let error exn cause = R.Error { log = build_log_of_exn exn; cause } in
   match action with
   | (`Change _ | `Reinstall _ | `Remove _) ->
     assert false
@@ -253,7 +248,7 @@ let process_package_result
     *)
     let report = match action_result with
       | `Aborted deps ->
-        Some (Aborted { deps })
+        Some (R.Aborted { deps })
       | `Successful _ ->
         None
       | `Exception exn ->
@@ -266,26 +261,25 @@ let process_package_result
   | `Install package ->
     let report = match action_result with
       | `Aborted deps ->
-        Aborted { deps }
+        R.Aborted { deps }
       | `Exception exn ->
         error exn `Install
       | `Successful (installed, _removed) ->
         let changes = (* FIXME *)
-          ignore installed; Changes in
+          ignore installed; R.Changes in
         let log = (* FIXME *)
           ["TODO"] in
         Success { log; changes }
     in Some (package, report)
 
-let retire_cover_state
-    ~(switch_state : Switch_state.t)
-    cover_state
+let retire_cover_state ~st ~switch
   =
-  let repo_path = switch_state.cover_state_repo.path in
-  let past_timestamps = switch_state.past_timestamps in
-  let timestamp_s = cover_state.Cover_state.timestamp.data in
+  let workdir = State.get_workdir st in
+  let repo_path = State.(d ~workdir @@ cover_state_path ~switch) in
+  let past_timestamps = State.(d ~workdir (past_timestamps_path ~switch)) in
+  let timestamp_value = State.(read st (timestamp_path ~switch)) in
   let cur_basename = File.Base.to_string (File.basename_dir repo_path) in
-  mv repo_path File.Op.(past_timestamps / (cur_basename ^ "_" ^ timestamp_s))
+  mv repo_path File.Op.(past_timestamps / (cur_basename ^ "_" ^ timestamp_value))
 
 (* Recover or initialize an opam_root with an up-to-date repository *)
 let recover_opam_root ~workdir ~repo_url opamroot =
@@ -341,12 +335,12 @@ let recover_opam_root ~workdir ~repo_url opamroot =
     end;
     log "Done updating the repository."
 
-let recover_opam_switch ~compiler ~compiler_variant ~switch_name =
+let recover_opam_switch ~compiler ~compiler_variant ~switch =
   OpamGlobalState.with_ `Lock_write @@ fun gt ->
   let _gt =
-    if not (OpamGlobalState.switch_exists gt switch_name) then begin
+    if not (OpamGlobalState.switch_exists gt switch) then begin
       log "Creating new opam switch %s" compiler_variant;
-      let sw, gt = create_new_switch gt ~switch_name ~compiler in
+      let sw, gt = create_new_switch gt ~switch ~compiler in
       OpamSwitchState.drop sw;
       gt
     end else begin
@@ -355,7 +349,7 @@ let recover_opam_switch ~compiler ~compiler_variant ~switch_name =
          (just our repository)
          (this is a sanity check; it is very most likely the case) *)
       begin
-        OpamSwitchState.with_ `Lock_none gt ~switch:switch_name @@ fun sw ->
+        OpamSwitchState.with_ `Lock_none gt ~switch:switch @@ fun sw ->
         let global_repos = OpamGlobalState.repos_list gt in
         let sw_repos = OpamSwitchState.repos_list sw in
         let sw_repos = if sw_repos = [] then (
@@ -372,7 +366,7 @@ let recover_opam_switch ~compiler ~compiler_variant ~switch_name =
       (* TODO update/refine/fix this criterion, esp with switch invariants in
          mind? *)
       let sw_base_installed =
-        OpamSwitchState.with_ `Lock_none gt ~switch:switch_name
+        OpamSwitchState.with_ `Lock_none gt ~switch
           (fun sw ->
              PkgSet.inter
                sw.compiler_packages sw.installed) in
@@ -380,11 +374,11 @@ let recover_opam_switch ~compiler ~compiler_variant ~switch_name =
         log "Either the compiler %s is not installed or not in the \
              base packages of the switch" (OpamPackage.to_string compiler);
         log "Creating a new switch instead";
-        let (sw, gt) = recreate_switch gt ~switch_name ~compiler in
+        let (sw, gt) = recreate_switch gt ~switch ~compiler in
         OpamSwitchState.drop sw;
         gt
       end else begin
-        begin OpamSwitchState.with_ `Lock_none gt ~switch:switch_name @@ fun sw ->
+        begin OpamSwitchState.with_ `Lock_none gt ~switch @@ fun sw ->
           let _sw = OpamSwitchAction.set_current_switch gt sw in ()
         end;
         OpamGlobalState.unlock gt
@@ -395,7 +389,7 @@ let recover_opam_switch ~compiler ~compiler_variant ~switch_name =
 
 (* Are the packages currently installed in the opam switch compatible with
    the current cover element? *)
-let recover_opam_switch_for_plan ~switch_name ~universe ~compiler plan =
+let recover_opam_switch_for_plan ~switch ~universe ~compiler plan =
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
     OpamSwitchState.with_ `Lock_read gt @@ fun sw ->
     let elt_installs = Cover_elt_plan.installs plan in
@@ -414,13 +408,13 @@ let recover_opam_switch_for_plan ~switch_name ~universe ~compiler plan =
       log "Re-creating a fresh opam switch...";
       let _sw, _gt =
         OpamGlobalState.with_write_lock gt @@ fun gt ->
-        recreate_switch gt ~switch_name ~compiler in
+        recreate_switch gt ~switch ~compiler in
       ()
     end
 
 (* Archive the current cover element if necessary *)
-let recover_cover_state ~(selection : PkgSet.t) (cover_state : Cover_state.t) =
-  let already_built = Cover_state.resolved_packages cover_state in
+let recover_cover_state ~(selection : PkgSet.t) ~st ~switch : bool (* has_changed *) =
+  let already_built = State.resolved_packages st ~switch in
   let selection_already_built =
     PkgSet.inter already_built selection in
   let selection_remaining =
@@ -431,10 +425,8 @@ let recover_cover_state ~(selection : PkgSet.t) (cover_state : Cover_state.t) =
     (PkgSet.cardinal selection_already_built)
     (PkgSet.cardinal selection_remaining);
 
-  let has_changed = false in
-
-  match cover_state.cur_plan.data with
-  | None -> cover_state, has_changed
+  match State.(read st @@ cur_plan_path ~switch) with
+  | None -> false
   | Some plan ->
     (* A cover element was already being built.
 
@@ -442,78 +434,82 @@ let recover_cover_state ~(selection : PkgSet.t) (cover_state : Cover_state.t) =
        in useless work: the packages remaining to build
        are all part of the user selection.
     *)
-    let current_todo =
-      Cover_state.nonbuilt_useful_packages plan
-        (SerializedLog.items cover_state.cur_report) in
+    let current_todo = State.nonbuilt_useful_packages st ~switch plan in
     if PkgSet.subset current_todo selection
     then begin
       log "Reusing the current cover element";
-      cover_state, has_changed
+      false
     end else begin
       log "Archiving the current cover element";
       (* NB: here we archive the current element even though it has only
          been built partially (that's fine as long as we remember to
          consider cover elements only as the output of the solver for
          co-installable packages, not as the build log). *)
-      let _cover_elt, cover_state = Cover_state.archive_cur_elt cover_state in
-      cover_state, true
+      let _elt = State.archive_cur_elt st ~switch in
+      true
     end
 
 let recover_switch_state
     ~(repo_url: OpamUrl.t)
     ~(selection: PkgSet.t)
-    (switch_state: Switch_state.t)
+    ~st ~switch
   =
   let repo_timestamp = get_repo_timestamp repo_url in
-  let cover_state_repo =
-    match switch_state.cover_state_repo.head with
-    | Some cover_state when repo_timestamp = cover_state.timestamp.data ->
-      log "Found an existing cover state for the current timestamp";
-      let cover_state, has_changed =
-        recover_cover_state ~selection cover_state in
-      if not has_changed then
-        (* Avoid polluting the git history with identity commits *)
-        switch_state.cover_state_repo
-      else
-        Repo.commit_new_head ~sync:Cover_state.sync "Update cover state"
-          { switch_state.cover_state_repo with head = Some cover_state }
-    | _ ->
-      (* Start over with a fresh cover state for the current timestamp *)
-      begin match switch_state.cover_state_repo.head with
-        | None -> ()
-        | Some cover_state ->
-          log "Existing cover state is for an old repo timestamp";
-          (* There is an existing cover_state, but its timestamp does not match
-             the one of the repository. Retire the cover_state
-             before creating a new one *)
-          retire_cover_state ~switch_state cover_state;
-      end;
-      log "Initialize a fresh cover state";
-      (* This initializes a fresh cover_state repository; it contains
-         no data at this point (i.e. [cover_state_repo.head = None]) *)
-      let cover_state_repo =
-        Repo.load_and_clean
-          ~path:switch_state.cover_state_repo.path
-          ~load:(fun ~dir:_ -> assert false (* there is no data to load *)) in
-      (* Add some data to the directory (the initial cover state for our
-         packages selection). *)
-      let cover_state = Cover_state.create
-          ~dir:switch_state.cover_state_repo.path
-          ~timestamp:repo_timestamp in
-      Repo.commit_new_head ~sync:Cover_state.sync "Initial cover state"
-        { cover_state_repo with head = Some cover_state }
-  in
-  { switch_state with cover_state_repo }
+  if State.(exists st @@ cover_state_path ~switch)
+  && State.(read st @@ timestamp_path ~switch) = repo_timestamp
+  then begin
+    log "Found an existing cover state for the current timestamp";
+    let has_changed =
+      recover_cover_state ~selection ~st ~switch in
+    if not has_changed then
+      (* Avoid polluting the git history with identity commits *)
+      ()
+    else
+      State.(commit st (cover_state_path ~switch) ~msg:"Update cover state")
+  end else begin
+    (* Start over with a fresh cover state for the current timestamp *)
+    if State.(exists st @@ cover_state_path ~switch) then begin
+      log "Existing cover state is for an old repo timestamp";
+      (* There is an existing cover_state, but its timestamp does not match
+         the one of the repository. Retire the cover_state
+         before creating a new one *)
+      retire_cover_state ~st ~switch;
+    end;
+    log "Initialize a fresh cover state";
+    (* This initializes a fresh cover_state repository; it contains
+       no data at this point (i.e. [cover_state_repo.head = None]) *)
+    State.(mkdir st @@ cover_state_path ~switch);
+    (* Initialize the directory. *)
+    (* NOTE: we need to provide the timestamp explicitly, but for the rest we
+       could have an [autoinit] function that would initialize the rest using
+       the default values from the schema.
 
+       Alternatively, we could make it so [State.read] auto-creates files
+       using default values when trying to read from a file that does not
+       exist (currently this auto-creation is only done once by [State.load]).
+       However this becomes a bit tricky if one needs to do it in depth and
+       create directories...
+
+       For now it seems simpler to require that when one creates a directory,
+       one manually initializes it so that it satisfies the schema. *)
+    State.(write st @@ timestamp_path ~switch) repo_timestamp;
+    State.(write st @@ past_elts_path ~switch) [];
+    State.(write st @@ cur_plan_path ~switch) None;
+    State.(write st @@ cur_report_path ~switch) [];
+    State.(write st @@ uninst_path ~switch) PkgSet.empty;
+    State.(commit st ~msg:"Initial cover state" @@ cover_state_path ~switch)
+  end
 
 let build
-    ~(switch_name : switch)
+    ~(st : State.t)
+    ~(switch : switch)
     ~(compiler : package)
     ~(universe : universe)
     ~(universe_cycles : PkgSet.t list list)
     ~(to_install: PkgSet.t)
-    (initial_timestamp : Cover_state.t Repo.t)
   =
+  let switch_o = switch in
+  let switch = OpamSwitch.to_string switch_o in
   (* Build loop:
      - compute the next element of the cover (if needed);
      - build all packages of this element;
@@ -533,88 +529,68 @@ let build
   let rec start_build
       ~(universe : universe)
       ~(to_install: PkgSet.t)
-      (cover_state_repo : Cover_state.t Repo.t)
     =
-    let cover_state = CCOption.get_exn_or "?" cover_state_repo.head in
-    match cover_state.cur_plan.data with
+    match State.(read st @@ cur_plan_path ~switch) with
     | None ->
-       build_next_cover_element ~universe ~to_install cover_state_repo cover_state
+       build_next_cover_element ~universe ~to_install
     | Some cover_elt ->
-       build_cover_element ~universe ~to_install cover_state_repo cover_state cover_elt
+       build_cover_element ~universe ~to_install cover_elt
 
-  and finish_build (cover_state_repo : Cover_state.t Repo.t) (cover_state : Cover_state.t) =
+  and finish_build () =
+    let uninst = State.(read st @@ uninst_path ~switch) in
     log "Finished building all packages of the selection \
          (%d uninstallable packages)"
-      (PkgSet.cardinal cover_state.uninst.data);
-    cover_state_repo
+      (PkgSet.cardinal uninst);
+    ()
 
   and build_next_cover_element
     ~(universe : universe)
     ~(to_install: PkgSet.t)
-    (cover_state_repo : Cover_state.t Repo.t)
-    (cover_state : Cover_state.t)
   =
     if PkgSet.is_empty to_install then
-      finish_build cover_state_repo cover_state
+      finish_build ()
     else begin
       log "Computing the next element...";
       let elt, remaining =
         Cover_elt_plan.compute
           ~make_request:(Lib.make_request_maxsat ~cycles:universe_cycles)
           ~universe ~to_install in
-      let commit_cover_state msg cover_state =
-        Repo.commit_new_head ~sync:Cover_state.sync msg
-          { cover_state_repo with head = Some cover_state } in
       if PkgSet.is_empty elt.useful then begin
         assert (PkgSet.equal to_install remaining);
-        let cover_state =
-          { cover_state with
-            uninst = { cover_state.uninst with data = remaining };
-          } in
-        let cover_state_repo =
-          commit_cover_state "No new element; build loop done" cover_state in
-        finish_build cover_state_repo cover_state
+        State.(write st @@ uninst_path ~switch) remaining;
+        State.(commit ~msg:"No new element; build loop done" st @@ cover_state_path ~switch);
+        finish_build ()
       end else begin
-        let cover_state =
-          { cover_state with
-            cur_plan = { cover_state.cur_plan with data = Some elt };
-          } in
-        let cover_state_repo =
-          commit_cover_state "New element computed" cover_state in
-        build_cover_element ~universe ~to_install cover_state_repo cover_state elt
+        State.(write st @@ cur_plan_path ~switch) (Some elt);
+        State.(commit ~msg:"New element computed" st @@ cover_state_path ~switch);
+        build_cover_element ~universe ~to_install elt
       end
     end
 
   and build_cover_element
     ~(universe : universe)
     ~(to_install: PkgSet.t)
-    (cover_state_repo : Cover_state.t Repo.t)
-    (cover_state : Cover_state.t)
     (plan : Cover_elt_plan.t)
     =
     (* Note: we recover after a program restart,
        but also when starting a new cover element. *)
-    recover_opam_switch_for_plan ~switch_name ~universe ~compiler plan;
+    recover_opam_switch_for_plan ~switch:switch_o ~universe ~compiler plan;
 
     (* The cover element can now be built in the current opam switch *)
-    let cover_state = ref cover_state in
     let update_cover_state package_action action_result =
       match process_package_result package_action action_result with
       | None -> ()
       | Some report_item ->
-        cover_state := Cover_state.add_item_to_report report_item !cover_state;
-        let repo =
-          Repo.commit_new_head ~sync:Cover_state.sync
-            (Printf.sprintf "New report for package %s"
-               (OpamPackage.to_string (fst report_item)))
-            { cover_state_repo with head = Some !cover_state } in
-        cover_state := CCOption.get_exn_or "?" repo.head
+        State.(append st @@ cur_report_path ~switch) report_item;
+        let msg = Printf.sprintf "New report for package %s"
+            (OpamPackage.to_string (fst report_item)) in
+        State.(commit st ~msg @@ cover_state_path ~switch);
     in
 
-    let cover_state =
+    begin
       OpamGlobalState.with_ `Lock_none @@ fun gs ->
       OpamSwitchState.with_ `Lock_write gs @@ fun sw ->
-      let (sw, res) =
+      let (_sw, res) =
         OpamSolution.apply sw
           ~ask:false
           ~requested:OpamPackage.Name.Set.empty
@@ -623,17 +599,12 @@ let build
           plan.Cover_elt_plan.solution
       in
       ignore res; (* we updated the cover state report incrementally *)
-      OpamSwitchState.drop sw;
-      !cover_state
-    in
+    end;
 
     (* Update the cover state *)
-    let cover_elt, cover_state = Cover_state.archive_cur_elt cover_state in
-
-    let cover_state_repo =
-      Repo.commit_new_head ~sync:Cover_state.sync
-        "Built the current cover element"
-        { cover_state_repo with head = Some cover_state } in
+    let cover_elt = State.archive_cur_elt st ~switch in
+    let cover_elt = CCOption.get_exn_or "?" cover_elt in
+    State.(commit st ~msg:"Built the current cover element" @@ cover_state_path ~switch);
     log "Finished building the current cover element";
 
     let universe, to_install =
@@ -641,7 +612,7 @@ let build
         let (_plan, report) = cover_elt in
         PkgMap.fold (fun package result (suc, err) ->
           match result with
-          | Success _ -> (PkgSet.add package suc, err)
+          | Data.Package_report.Success _ -> (PkgSet.add package suc, err)
           | Error _ -> (suc, PkgSet.add package err)
           | Aborted _ -> (suc, err)
         ) report (PkgSet.empty, PkgSet.empty)
@@ -649,15 +620,20 @@ let build
       remove_from_universe universe errors,
       PkgSet.Op.(to_install -- successes -- errors)
     in
-    build_next_cover_element ~universe ~to_install cover_state_repo cover_state
+    build_next_cover_element ~universe ~to_install
 
   in
-  start_build ~universe ~to_install initial_timestamp
+  start_build ~universe ~to_install
 
 let run_cmd ~repo_url ~working_dir ~compiler_variant ~package_selection =
-  let workdir = get_or_fatal (validate_workdir working_dir)
-      "%s is not empty but does not contain an %s"
-      working_dir opamroot_path in
+  (* create [working_dir] if it does not exist *)
+  mkdir (Dir.of_string working_dir);
+
+  (* Create a state handle for the workdir, checking that it conforms to the
+     expected schema, creating directories/files with default values if needed
+     *)
+  let workdir = working_dir in
+  let st = State.load ~workdir in
 
   let compiler = get_or_fatal (validate_compiler_variant compiler_variant)
       "Invalid compiler variant: %s%t" compiler_variant
@@ -676,7 +652,7 @@ let run_cmd ~repo_url ~working_dir ~compiler_variant ~package_selection =
       "Repo url must be a local git clone of an opam-repository" in
 
   let opamroot =
-    let root_dir = OpamFilename.Op.(workdir / opamroot_path) in
+    let root_dir = State.(d ~workdir opamroot_path) in
     OpamStateConfig.opamroot ~root_dir ()
   in
 
@@ -691,46 +667,42 @@ let run_cmd ~repo_url ~working_dir ~compiler_variant ~package_selection =
   recover_opam_root ~workdir ~repo_url opamroot;
   (* We now have an initialized opamroot with an updated repository *)
 
-  let switch_name = OpamSwitch.of_string compiler_variant in
-  recover_opam_switch ~compiler ~compiler_variant ~switch_name;
+  let switch_o = OpamSwitch.of_string compiler_variant in
+  let switch = compiler_variant in
+  recover_opam_switch ~compiler ~compiler_variant ~switch:switch_o;
 
-  OpamStateConfig.update ~current_switch:switch_name ();
-  log "Using opam switch %s" (OpamSwitch.to_string switch_name);
+  OpamStateConfig.update ~current_switch:switch_o ();
+  log "Using opam switch %s" switch;
 
   (* We have a switch of the right name, attached to the right repository.
      Installed packages in the switch include at least our compiler and
      related base packages (there can also be other packages). *)
 
-  let work_state =
-    let view = Work_state.View_single.load_or_create compiler in
-    Work_state.load_or_create ~view ~workdir in
-  let switch_state = work_state.view in
   (* TODO: do we want to filter the universe to exclude packages that we know
      are broken? *)
   let universe = switch_universe () |> prepare_universe in
-  log "Computing cycles in the packages universe...";
-  let universe_cycles = Lib.compute_universe_cycles universe in
-  log "Done";
+  let universe_cycles =
+      log "Computing cycles in the packages universe...";
+      let universe_cycles = Lib.compute_universe_cycles universe in
+      log "Done";
+      universe_cycles
+    )
+  in
 
   let selection_packages = compute_package_selection universe package_selection in
   log "User package selection includes %d packages"
     (PkgSet.cardinal selection_packages);
 
-  let switch_state : Switch_state.t =
-    recover_switch_state ~repo_url ~selection:selection_packages switch_state in
+  recover_switch_state ~st ~repo_url ~selection:selection_packages ~switch;
 
   let universe, to_install =
-    match switch_state.cover_state_repo.head with
-      | None -> universe, selection_packages
-      | Some cover_state ->
-         remove_from_universe universe (Cover_state.broken_packages cover_state),
-         PkgSet.diff selection_packages (Cover_state.resolved_packages cover_state)
+    let broken = State.broken_packages st ~switch in
+    let resolved = State.resolved_packages st ~switch in
+    remove_from_universe universe broken,
+    PkgSet.diff selection_packages resolved
   in
 
-  let _cover_state_repo : Cover_state.t Repo.t =
-    build ~switch_name ~compiler ~universe ~universe_cycles ~to_install
-      switch_state.cover_state_repo
-  in
+  build ~st ~switch:switch_o ~compiler ~universe ~universe_cycles ~to_install;
   log "Done";
   ()
 

--- a/src/marracheck.ml
+++ b/src/marracheck.ml
@@ -477,7 +477,7 @@ let recover_switch_state
     end;
     log "Initialize a fresh cover state";
     (* This initializes a fresh cover_state repository; it contains
-       no data at this point (i.e. [cover_state_repo.head = None]) *)
+       no data at this point *)
     State.(mkdir st @@ cover_state_path ~switch);
     (* Initialize the directory. *)
     (* NOTE: we need to provide the timestamp explicitly, but for the rest we


### PR DESCRIPTION
I recently realized that there is (was) a performance issue with marracheck,
with it being a bottleneck when installing small packages. (marracheck would
spend its time at 100% cpu instead of being I/O bound)

The culprit was tracked down (using perf + a flamegraph generating script,
thanks https://github.com/ocaml-bench/notes/blob/master/profiling_notes.md) to
be too-naive serialization code: when adding a package report for a single
package (in a file which was designed to be easily appended to), we also re-dump
the entire cover state, solution, etc, and spend a lot of CPU time in *.to_json
functions.

Part of the issue comes from the fact that the current API of state.ml is not
great and makes it easy to implement inefficient code from a serialization point
of view.

This in turn motivated me to rewrite state.ml, with the following goals in mind:

- introduce an abstraction barrier. Current state.ml offers no abstraction
  (consequently I have now completely forgotten how to use it correctly).

- provide a simpler API. Current state.ml allows you to load the entire state
  from the disk as a record, that you update in-memory, and have to remember to
  re-dump to disk enough often (and then you want to do this efficiently without
  rewriting everything, which is tricky, and was the cause of the performance
  bug).

- make it easy to change the filesystem layout. Our on-filesystem database
  resolves around a small number of concepts: files holding serialized data,
  directories (sometimes indexed by git). It would be nice to be able to handle
  basic file reading and serialization in a generic manner, and it would be nice
  to be able to easily update the layout of the filesystem (e.g. to add more
  pieces of serialized data when we need them etc) in a somewhat declarative
  manner.


The new state.ml (and fs.ml and data.ml) (this PR) implements the following
strategy:

- it implements a simpler API where the client does not need to hold a piece of
  state that it updates separately and needs to sync to disk from time to time.
  Instead, the API is such that :
  + everytime the client needs data, it reads it from the disk;
  + everytime the client updates data, it writes it to the disk.

  If performance (of e.g. reading the same data many times) is a concern, it is
  trivial to implement caching as an optimization, without changing the API.

- the basic functionality for serializing/deserializing files/handling git
  repositories is provided in a generic module, parameterized by a "schema" of
  the on-filesystem "database", which describes declaratively the expected
  layout of the filesystem.

  (and to some extend handles stuff like automatically creating files with
  default values if they don't exist etc)

  This is provided by `fs.{ml,mli}`.

  This functionality is therefore agnostic wrt the actual layout of the
  marracheck data, and as such facilitates point 3 above (changing filesystem
  layout).

- The `Fs.Make` functor, parameterized by the database "schema" is instantiated
  once in `state.ml`, with the current "marracheck" schema.

  It then wraps it with a number of helpers to access the files that we know are
  in our database, and a number of higher-level operations that were in the
  previous state.ml.

- `data.ml` gathers the serialization functions (`of_json`,`to_json`) for the
  data we want to store in files.

- due to this two-layers abstraction (we provide a functor which we only
  instantiate once), we do pay for some additional "dynamic typing" checks (e.g.
  we dynamically check that paths belong to the schema, possibly several times
  for the "same" path). It would be easy to add a cache for those, but it
  doesn't seem to be an issue in practice (after some quick profiling).

- I did check that the performance bug is gone. :-)



I'm opening this as a PR to possibly allow for comments wrt the APIs in `fs.mli`
and `state.mli` ; I spent a bit of time on those trying to find a good balance
between phantom types-based trickery and usability, but there may be some
possible further improvements...

cc @gasche 