### PR TITLE
Cmdliner 1.1.0 and Opam global/build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,23 @@ make r
 
 This will build an `open-wbo-inc_release` binary, that you need to copy
 somewhere where it can be found through `$PATH`.
+
+## Running marracheck
+
+Finally, marracheck requires an opam repository available locally (for example
+with `git clone https://github.com/ocaml/opam-repository`). Then marracheck
+can be run with:
+
+```sh
+dune exec -- src/marracheck.exe run \
+  /path/to/opam-repository \
+  /path/to/marracheck-state \
+  ocaml-base-compiler.4.13.1
+```
+
+This will attempt to compile all versions of all packages compatible with ocaml
+4.13.1.  The `/path/to/marracheck-state` directory will contain a binary
+`cache` directory of the packages, a standard `opamroot`, and a `switches`
+directory that tracks the progress of marracheck.  The behavior of opam invoked
+by marracheck can be configured with environment variables (see
+`opam env --help` for a full list.)

--- a/marracheck.opam
+++ b/marracheck.opam
@@ -30,7 +30,7 @@ depends: [
 # Dependencies for the vendored opam libs
 # (see the .opam files in the vendored-opam git submodule)
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "1.1.0"}
   "ocamlgraph"
   "cppo"
   "mccs" {>= "1.1+9"}

--- a/src/marracheck.ml
+++ b/src/marracheck.ml
@@ -829,7 +829,7 @@ let run_term =
     & opt (conv ~docv (parser, printer)) `All
     & info
       ~docv
-      ~doc:"the selection of packages to build with marracheck:\n
+      ~doc:"The selection of packages to build with marracheck:\n
             - $(i,all) will build all installable packages for this compiler
               version in the switch\n
             - $(i,packages(foo, bar, baz)) will build the listed packages
@@ -850,24 +850,25 @@ let run_term =
         $ arg_repo_url
         $ arg_working_dir
         $ arg_compiler_variant
-        $ arg_package_selection),
-  Term.info "run"
-    ~doc:"Build the selected opam packages from the given opam repository. \
-          All state of marracheck (build cache, action logs, task set...) \
-          are stored persistently in the working directory.\n"
+        $ arg_package_selection)
+  |> Cmd.v
+       (Cmd.info "run"
+          ~doc:"Build the selected opam packages from the given opam repository. \
+                All state of marracheck (build cache, action logs, task set...) \
+                are stored persistently in the working directory.\n")
 
 let cache_term =
   let open Cmdliner in
-  Term.(const cache_cmd $ const ()),
-  Term.info "cache"
-    ~doc:"Maintenance operation on the working cache \
-          of a marracheck working directory.\n
-          (TODO Not implemented yet)"
+  Term.(const cache_cmd $ const ())
+  |> Cmd.v
+       (Cmd.info "cache"
+          ~doc:"Maintenance operation on the working cache \
+                of a marracheck working directory.\n
+                (TODO Not implemented yet)")
 
 let usage_term =
   let open Cmdliner in
-  Term.(ret (const (`Help (`Auto, None)))),
-  Term.info "marracheck"
+  Cmd.info "marracheck"
     ~doc:"build many packages from an opam repository"
     ~man:[
       `S Manpage.s_description;
@@ -881,8 +882,8 @@ let usage_term =
       `Pre "marracheck run tmp/opam-repository tmp/working-dir 4.07.1";
       `Pre "marracheck cache clean # TODO";
     ]
-    ~exits:Term.default_exits (* TODO *)
+    ~exits:Cmd.Exit.defaults (* TODO *)
 
 let () =
   let open Cmdliner in
-  Term.(exit @@ eval_choice usage_term [run_term; cache_term])
+  exit @@ Cmd.eval @@ Cmd.group usage_term [run_term; cache_term]


### PR DESCRIPTION
The main motivation was to enable opam's `--debug --verbose` to get more feedback when opam is hanging for minutes, but there are a few more settings that may be interesting:
- `--fake` to spare a few cycles/disk space when debugging elements cover (but note that `--dry-run` doesn't work as it doesn't register the switch!)
- `--keep-build-dir`, `--with-doc`, `--with-test` for a slightly different usage
- `--no-depexts`, `--yes`, `--no`, etc for running without human intervention

Opam's `--switch` could cause conflicts with marracheck's positional argument, so the proposed fix is to use the opam argument (with an arbitrary default of `4.13.1` if missing):

```sh
dune exec -- ./src/marracheck.exe run --debug --verbose --no-depexts \
  /path/to/opam-repository \
  /path/to/marracheck-data \
  --switch=ocaml-base-compiler.4.13.1 # <-- syntax breaking change!
```

While the extra settings are convenient, I'm not 100% happy that the `--help` becomes noisy with all the random opam options... And it's very likely that some of these options will interact badly with marracheck, although I'm really not sure which one should be forbidden / provide no value.